### PR TITLE
added symbol.Table

### DIFF
--- a/symbol/api.symbol.go
+++ b/symbol/api.symbol.go
@@ -1,0 +1,71 @@
+package symbol
+
+import (
+	"github.com/dgraph-io/badger/v3"
+)
+
+// Creates a new symbol.Table and attaches it to the given db.
+// If db == nil, the symbol.Table will operate in memory-only mode.
+func OpenTable(db *badger.DB, opts TableOpts) (Table, error) {
+	return openTable(db, opts)
+}
+
+// ID is a persistent integer value associated with an immutable string or buffer value.
+// If an ID == 0, it denotes nil or unassigned.
+type ID uint64
+
+// IDSz is the byte size of a Table ID (big endian)
+// This means an app issuing a new symbol ID every millisecond would need 35 years to hit the limit.
+// Even in this case, the limiting factor is symbol storage (not an an ID issue limit of 2^40).
+const IDSz = 5
+
+// MinIssuedID specifies a minimum ID value for newly issued IDs.
+//
+// ID values less than this value are reserved for clients to represent hard-wired or "out of band" meaning.
+// "Hard-wired" meaning that Table.SetSymbolID() can be used for IDs less than MinIssuedID with no risk
+// of an ID being issued on top of it.
+const MinIssuedID = 1000
+
+// Table is a persistent storage of value-ID pairs, designed for high-performance lookup of an ID or buffer.
+// This implementation is indended to handle extreme loads, leveraging:
+//      - ID-value pairs are cached once read, offering subsequent O(1) access
+//      - Internal value allocations are pooled. The default TableOpts.PoolSz of 16k means
+//        thousands of buffers can be issued or read under only a single allocation.
+//
+// All calls are threadsafe.
+type Table interface {
+
+	// Returns the symbol ID associated with the given string/buffer value.
+	// The given buffer is never retained.
+	//
+	// If not found and autoIssue == true, a new entry is created and the new ID returned.
+	// Newly issued IDs are always > 0 and use the lower bytes of the returned ID (see type ID comments).
+	//
+	// If not found and autoIssue == false, 0 is returned.
+	GetSymbolID(value []byte, autoIssue bool) ID
+
+	// Associates the given buffer value to the given symbol ID, allowing multiple values to be mapped to a single ID.
+	// If ID == 0, then this is the equivalent to GetSymbolID(value, true).
+	SetSymbolID(value []byte, ID ID) ID
+
+	// Returns the string/buffer value associated with the given symbol ID.
+	// If the ID is <= 0 or not found, nil is returned.
+	LookupID(ID ID) []byte
+
+	// Flushes any changes and internally closes
+	// Any subsequent access to this interface is undefined.
+	Close()
+}
+
+type TableOpts struct {
+	WorkingSizeHint int   // anticipated number of entries in working set
+	PoolSz          int32 // Value backing buffer allocation pool sz
+	DbKeyPrefix     byte  // Only used in persistent db mode
+}
+
+// DefaultOpts is a suggested set of options.
+var DefaultTableOpts = TableOpts{
+	WorkingSizeHint: 600,
+	PoolSz:          16 * 1024,
+	DbKeyPrefix:     0xFA,
+}

--- a/symbol/api.symbol.go
+++ b/symbol/api.symbol.go
@@ -1,7 +1,7 @@
 package symbol
 
 import (
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v2"
 )
 
 // Creates a new symbol.Table and attaches it to the given db.
@@ -35,7 +35,7 @@ const MinIssuedID = 1000
 // All calls are threadsafe.
 type Table interface {
 
-	// Returns the symbol ID associated with the given string/buffer value.
+	// Returns the symbol ID previously associated with the given string/buffer value.
 	// The given buffer is never retained.
 	//
 	// If not found and autoIssue == true, a new entry is created and the new ID returned.
@@ -48,8 +48,10 @@ type Table interface {
 	// If ID == 0, then this is the equivalent to GetSymbolID(value, true).
 	SetSymbolID(value []byte, ID ID) ID
 
-	// Returns the string/buffer value associated with the given symbol ID.
+	// Returns the byte string previously associated with the given symbol ID.
 	// If the ID is <= 0 or not found, nil is returned.
+	// 
+	// The buf returned conveniently retains scope until Close() is called (and is read-only). 
 	LookupID(ID ID) []byte
 
 	// Flushes any changes and internally closes

--- a/symbol/api.symbol.go
+++ b/symbol/api.symbol.go
@@ -48,14 +48,13 @@ type Table interface {
 	// If ID == 0, then this is the equivalent to GetSymbolID(value, true).
 	SetSymbolID(value []byte, ID ID) ID
 
-	// Returns the byte string previously associated with the given symbol ID.
-	// If the ID is <= 0 or not found, nil is returned.
-	// 
-	// The buf returned conveniently retains scope until Close() is called (and is read-only). 
+	// Looks up and returns the byte string previously associated with the given symbol ID.
+	// The returned buf conveniently retains scope indefinitely (and is read only).
+	// If ID is invalid or not found, nil is returned.
 	LookupID(ID ID) []byte
 
-	// Flushes any changes and internally closes
-	// Any subsequent access to this interface is undefined.
+	// Releases internal references to the underlying database.
+	// Subsequent access to this Table instance is defined but limited to what is already cached.
 	Close()
 }
 

--- a/symbol/hash.go
+++ b/symbol/hash.go
@@ -1,0 +1,40 @@
+package symbol
+
+import "unsafe"
+
+// HashBuf is the hash function used by go map, it uses available hardware instructions.
+// NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
+func HashBuf(data []byte) uint64 {
+	ss := (*stringStruct)(unsafe.Pointer(&data))
+	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
+}
+
+// HashStr is the hash function used by go map, it utilizes available hardware instructions.
+// NOTE: The hash seed changes for every process. So, this cannot be used as a persistent hash.
+func HashStr(str string) uint64 {
+	ss := (*stringStruct)(unsafe.Pointer(&str))
+	return uint64(memhash(ss.str, 0, uintptr(ss.len)))
+}
+
+// AP Hash Function -- deprecated in place of HashBuf.
+// https://www.partow.net/programming/hashfunctions/#AvailableHashFunctions
+func APHash64(buf []byte) uint64 {
+	var hash uint64 = 0xaaaaaaaaaaaaaaaa
+	for i, b := range buf {
+		if (i & 1) == 0 {
+			hash ^= ((hash << 7) ^ uint64(b) ^ (hash >> 3))
+		} else {
+			hash ^= (^((hash << 11) ^ uint64(b) ^ (hash >> 5)) + 1)
+		}
+	}
+	return hash
+}
+
+type stringStruct struct {
+	str unsafe.Pointer
+	len int
+}
+
+//go:noescape
+//go:linkname memhash runtime.memhash
+func memhash(p unsafe.Pointer, h, s uintptr) uintptr

--- a/symbol/table.go
+++ b/symbol/table.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/dgraph-io/badger/v3"
+	"github.com/dgraph-io/badger/v2"
 )
 
 func (id ID) WriteTo(io []byte) []byte {

--- a/symbol/table.go
+++ b/symbol/table.go
@@ -1,0 +1,363 @@
+package symbol
+
+import (
+	"bytes"
+	"encoding/binary"
+	"sync"
+	"sync/atomic"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/planet5d/go-cedar/bufs"
+)
+
+func (id ID) WriteTo(io []byte) []byte {
+	return append(io, // big endian marshal
+		byte(uint64(id)>>32),
+		byte(uint64(id)>>24),
+		byte(uint64(id)>>16),
+		byte(uint64(id)>>8),
+		byte(id))
+}
+
+func (id *ID) ReadFrom(in []byte) int {
+	*id = ID(
+		(uint64(in[0]) << 32) |
+			(uint64(in[1]) << 24) |
+			(uint64(in[2]) << 16) |
+			(uint64(in[3]) << 8) |
+			(uint64(in[4])))
+
+	return IDSz
+}
+
+const (
+	xValueIndex = byte(0xFE)
+	xNextID     = byte(0xFF)
+)
+
+func openTable(db *badger.DB, opts TableOpts) (Table, error) {
+	st := &symbolTable{
+		opts:          opts,
+		db:            db,
+		nextID:        MinIssuedID,
+		curBufPoolIdx: -1,
+		valueCache:    make(map[uint64]kvEntry, opts.WorkingSizeHint),
+		tokenCache:    make(map[ID]kvEntry, opts.WorkingSizeHint),
+	}
+
+	if st.db != nil {
+		seqKey := []byte{st.opts.DbKeyPrefix, 0xFF, xNextID}
+		txn := db.NewTransaction(true)
+		defer txn.Discard()
+
+		// Initialize the sequence key if not present
+		_, err := txn.Get(seqKey)
+		if err == badger.ErrKeyNotFound {
+			var buf [8]byte
+
+			binary.BigEndian.PutUint64(buf[:], MinIssuedID)
+			err = txn.Set(seqKey, buf[:])
+			if err == nil {
+				err = txn.Commit()
+			}
+		}
+		if err != nil {
+			panic(err)
+		}
+
+		// TODO: open lease on-demand (vs always) so two writes aren't assured when only reading a db.
+		st.nextIDSeq, err = db.GetSequence(seqKey, 300)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return st, nil
+}
+
+func (st *symbolTable) Close() {
+	if st.nextIDSeq != nil {
+		st.nextIDSeq.Release()
+		st.nextIDSeq = nil
+	}
+	st.valueCache = nil
+	st.tokenCache = nil
+	st.bufPools = nil
+	st.db = nil
+}
+
+type kvEntry struct {
+	symID   ID
+	poolIdx int32
+	poolOfs int32
+	len     int32
+}
+
+func (st *symbolTable) equals(kv *kvEntry, buf []byte) bool {
+	sz := int32(len(buf))
+	if sz != kv.len {
+		return false
+	}
+	return bytes.Equal(st.bufPools[kv.poolIdx][kv.poolOfs:kv.poolOfs+sz], buf)
+}
+
+func (st *symbolTable) bufForEntry(kv *kvEntry) []byte {
+	if kv.symID == 0 {
+		return nil
+	}
+	return st.bufPools[kv.poolIdx][kv.poolOfs : kv.poolOfs+kv.len]
+}
+
+// symbolTable implements symbol.Table
+type symbolTable struct {
+	opts          TableOpts
+	db            *badger.DB
+	nextIDSeq     *badger.Sequence
+	nextID        uint64 // Only used if db == nil
+	valueCacheMu  sync.RWMutex
+	valueCache    map[uint64]kvEntry
+	tokenCacheMu  sync.RWMutex
+	tokenCache    map[ID]kvEntry
+	curBufPool    []byte
+	curBufPoolSz  int32
+	curBufPoolIdx int32
+	bufPools      [][]byte
+}
+
+func (st *symbolTable) getIDFromCache(buf []byte) ID {
+	hash := bufs.HashBuf(buf)
+
+	st.valueCacheMu.RLock()
+	defer st.valueCacheMu.RUnlock()
+
+	kv, found := st.valueCache[hash]
+	for found {
+		if st.equals(&kv, buf) {
+			return kv.symID
+		}
+		hash++
+		kv, found = st.valueCache[hash]
+	}
+
+	return 0
+}
+
+func (st *symbolTable) allocAndBindToID(buf []byte, bindTo ID) kvEntry {
+	hash := bufs.HashBuf(buf)
+
+	st.valueCacheMu.Lock()
+	defer st.valueCacheMu.Unlock()
+
+	kv, found := st.valueCache[hash]
+	for found {
+		if st.equals(&kv, buf) {
+			break
+		}
+		hash++
+		kv, found = st.valueCache[hash]
+	}
+
+	// No-op if already present
+	if found && kv.symID == bindTo {
+		return kv
+	}
+
+	// At this point we know [hash] will be the destination element
+	// Add a copy of the buf in our backing buf (in the heap).
+	// If we run out of space in our pool, we start a new pool
+	kv.symID = bindTo
+	{
+		kv.len = int32(len(buf))
+		if int(st.curBufPoolSz+kv.len) > cap(st.curBufPool) {
+			allocSz := max(st.opts.PoolSz, kv.len)
+			st.curBufPool = make([]byte, allocSz)
+			st.curBufPoolSz = 0
+			st.curBufPoolIdx++
+			st.bufPools = append(st.bufPools, st.curBufPool)
+		}
+		kv.poolIdx = st.curBufPoolIdx
+		kv.poolOfs = st.curBufPoolSz
+		copy(st.curBufPool[kv.poolOfs:kv.poolOfs+kv.len], buf)
+		st.curBufPoolSz += kv.len
+	}
+
+	// Place the now-backed copy at the open hash spot and return the alloced value
+	st.valueCache[hash] = kv
+
+	st.tokenCacheMu.Lock()
+	st.tokenCache[kv.symID] = kv
+	st.tokenCacheMu.Unlock()
+
+	return kv
+}
+
+func (st *symbolTable) GetSymbolID(val []byte, autoIssue bool) ID {
+	symID := st.getIDFromCache(val)
+	if symID != 0 {
+		return symID
+	}
+
+	symID = st.getsetValueIDPair(val, 0, autoIssue)
+	return symID
+}
+
+func (st *symbolTable) SetSymbolID(val []byte, symID ID) ID {
+	// If symID == 0, then behave like GetSymbolID(val, true)
+	return st.getsetValueIDPair(val, symID, symID == 0)
+}
+
+// getsetValueIDPair loads and returns the ID for the given value, and/or writes the ID and value assignment to the db,
+// also updating the cache in the process.
+//
+//  if symID == 0:
+//    if the given value has an existing value-ID association:
+//        the existing ID is cached and returned (mapID is ignored).
+//    if the given value does NOT have an existing value-ID association:
+//        if mapID == false, the call has no effect and 0 is returned.
+//        if mapID == true, a new ID is issued and new value-to-ID and ID-to-value assignments are written,
+//
+//  if symID != 0:
+//      if mapID == false, a new value-to-ID assignment is (over)written and any existing ID-to-value assignment remains.
+//      if mapID == true, both value-to-ID and ID-to-value assignments are (over)written.
+//
+func (st *symbolTable) getsetValueIDPair(val []byte, symID ID, mapID bool) ID {
+
+	if st.db == nil {
+		if symID == 0 && mapID {
+			symID = ID(atomic.AddUint64(&st.nextID, 1))
+		}
+	} else {
+		txn := st.db.NewTransaction(true)
+		defer txn.Discard()
+
+		// The value index is placed after the ID index
+		var (
+			keyBuf [128]byte
+			idBuf  [8]byte
+			err    error
+		)
+
+		keyBuf[0] = st.opts.DbKeyPrefix
+		keyBuf[1] = 0xFF
+		keyBuf[2] = xValueIndex
+		valKey := append(keyBuf[:3], val...)
+
+		var existingID ID
+		if symID == 0 || !mapID {
+
+			// Lookup the given value and get its existing ID
+			item, err := txn.Get(valKey)
+			if err == nil {
+				item.Value(func(buf []byte) error {
+					if len(buf) == IDSz {
+						existingID.ReadFrom(buf)
+					}
+					return nil
+				})
+			}
+		}
+
+		reassignID := false
+		reassignVal := false
+
+		if symID == 0 {
+			if existingID != 0 {
+				symID = existingID
+			} else if mapID {
+				var nextID uint64
+				nextID, err = st.nextIDSeq.Next()
+				if err == nil {
+					symID = ID(nextID)
+					reassignID = true
+					reassignVal = true
+				}
+			}
+		} else {
+			if existingID == 0 {
+				reassignVal = true
+				reassignID = true
+			} else if symID != existingID {
+				reassignVal = true
+				if mapID {
+					symID = existingID
+					reassignID = true
+				}
+			}
+		}
+
+		// If applicable, flush the new kv assignment change to the db
+		for err == nil && (reassignID || reassignVal) {
+
+			// set (value => ID) entry
+			idBuf[0] = st.opts.DbKeyPrefix
+			idKey := symID.WriteTo(idBuf[:1])
+			err := txn.Set(valKey, idKey[1:])
+
+			if err == nil {
+				if reassignID {
+					err = txn.Set(idKey, val)
+				}
+				if err == nil {
+					err = txn.Commit()
+				}
+			}
+
+			if err != badger.ErrConflict {
+				break
+			}
+
+			err = nil
+			txn.Discard()
+			txn = st.db.NewTransaction(true)
+		}
+
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	// Update the cache
+	if symID != 0 {
+		st.allocAndBindToID(val, symID)
+	}
+	return symID
+}
+
+func (st *symbolTable) LookupID(symID ID) []byte {
+	if symID == 0 {
+		return nil
+	}
+
+	st.tokenCacheMu.RLock()
+	kv, found := st.tokenCache[symID]
+	st.tokenCacheMu.RUnlock()
+
+	// If we have the ID in the cache, then just use that (hopefully most of the time)
+	if !found && st.db != nil {
+		txn := st.db.NewTransaction(false)
+		defer txn.Discard()
+
+		// Lookup the given ID in the db.
+		// We expect it to be found otherwise why lookup an ID that was never issued?
+		var idBuf [8]byte
+		idBuf[0] = st.opts.DbKeyPrefix
+		tokenKey := symID.WriteTo(idBuf[:1])
+		item, err := txn.Get(tokenKey)
+		if err == nil {
+			item.Value(func(val []byte) error {
+				kv = st.allocAndBindToID(val, symID)
+				return nil
+			})
+		}
+	}
+
+	return st.bufForEntry(&kv)
+}
+
+func max(a, b int32) int32 {
+	if a > b {
+		return a
+	} else {
+		return b
+	}
+}

--- a/symbol/table.go
+++ b/symbol/table.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 
 	"github.com/dgraph-io/badger/v3"
-	"github.com/planet5d/go-cedar/bufs"
 )
 
 func (id ID) WriteTo(io []byte) []byte {
@@ -125,7 +124,7 @@ type symbolTable struct {
 }
 
 func (st *symbolTable) getIDFromCache(buf []byte) ID {
-	hash := bufs.HashBuf(buf)
+	hash := HashBuf(buf)
 
 	st.valueCacheMu.RLock()
 	defer st.valueCacheMu.RUnlock()
@@ -143,7 +142,7 @@ func (st *symbolTable) getIDFromCache(buf []byte) ID {
 }
 
 func (st *symbolTable) allocAndBindToID(buf []byte, bindTo ID) kvEntry {
-	hash := bufs.HashBuf(buf)
+	hash := HashBuf(buf)
 
 	st.valueCacheMu.Lock()
 	defer st.valueCacheMu.Unlock()

--- a/symbol/table_test.go
+++ b/symbol/table_test.go
@@ -105,7 +105,7 @@ func fillTable(db *badger.DB, vals [][]byte, IDs []symbol.ID) {
 	// Populate the table with multiple workers all setting values at once
 	{
 		running := &sync.WaitGroup{}
-		numWorkers := 2
+		numWorkers := 5
 		for i := 0; i < numWorkers; i++ {
 			running.Add(1)
 			startAt := len(vals) * i / numWorkers

--- a/symbol/table_test.go
+++ b/symbol/table_test.go
@@ -10,8 +10,8 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/dgraph-io/badger/v3"
-	"github.com/planet5d/go-planet/symbol"
+	"github.com/dgraph-io/badger/v2"
+	"redwood.dev/symbol"
 )
 
 var gTest = make(chan error)

--- a/symbol/table_test.go
+++ b/symbol/table_test.go
@@ -1,0 +1,191 @@
+package symbol_test
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/dgraph-io/badger/v3"
+	"github.com/planet5d/go-planet/symbol"
+)
+
+var gTest = make(chan error)
+
+func TestTable(t *testing.T) {
+
+	go func() {
+		doFullTableTest(800011)
+		close(gTest)
+	}()
+
+	// wait for test to finish, fail the test on any errors
+	err := <-gTest
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func doFullTableTest(totalEntries int) {
+	dir, err := os.MkdirTemp("", "junk*")
+	if err != nil {
+		gTest <- err
+	}
+	defer os.RemoveAll(dir)
+
+	vals := make([][]byte, totalEntries)
+	for i := range vals {
+		vals[i] = []byte(strconv.Itoa(i))
+	}
+	IDs := make([]symbol.ID, totalEntries)
+
+	// Test memory only mode
+	fillTable(nil, vals, IDs)
+
+	// Test WITH a database
+	dbPathname := path.Join(dir, "test1")
+	opts := badger.DefaultOptions(dbPathname)
+	opts.Logger = nil
+
+	// 1) tortuously fill and write a table
+	{
+		db, err := badger.Open(opts)
+		if err != nil {
+			gTest <- err
+		}
+		fillTable(db, vals, IDs)
+		db.Close()
+	}
+
+	// 2) tortuously read and check the table
+	{
+		db, err := badger.Open(opts)
+		if err != nil {
+			gTest <- err
+		}
+		checkTable(db, vals, IDs)
+		db.Close()
+	}
+}
+
+const (
+	hardwireStart     = symbol.MinIssuedID - hardwireTestCount
+	hardwireTestCount = 101
+)
+
+func fillTable(db *badger.DB, vals [][]byte, IDs []symbol.ID) {
+	totalEntries := len(vals)
+
+	table, err := symbol.OpenTable(db, symbol.DefaultTableOpts)
+	if err != nil {
+		gTest <- err
+	}
+	defer table.Close()
+
+	// Test reserved symbol ID space -- set symbol IDs less than symbol.MinIssuedID
+	// Do multiple write passes to check overwrites don't cause issues.
+	for k := 0; k < 3; k++ {
+		for j := 0; j < hardwireTestCount; j++ {
+			idx := hardwireStart + j
+			symID := symbol.ID(idx)
+			symID_got := table.SetSymbolID(vals[idx], symID)
+			if symID_got != symID {
+				gTest <- errors.New("SetSymbolID failed setup check")
+			}
+		}
+	}
+
+	hardwireCount := int32(0)
+	hardwireCountPtr := &hardwireCount
+
+	// Populate the table with multiple workers all setting values at once
+	{
+		running := &sync.WaitGroup{}
+		numWorkers := 2
+		for i := 0; i < numWorkers; i++ {
+			running.Add(1)
+			startAt := len(vals) * i / numWorkers
+			go func() {
+				for j := 0; j < totalEntries; j++ {
+					idx := (startAt + j) % totalEntries
+					symID := table.GetSymbolID(vals[idx], true)
+					if symID < symbol.MinIssuedID {
+						atomic.AddInt32(hardwireCountPtr, 1)
+					}
+					stored := table.LookupID(symID)
+					if !bytes.Equal(stored, vals[idx]) {
+						gTest <- errors.New("LookupID failed setup check")
+					}
+					symID_got := table.SetSymbolID(vals[idx], symID)
+					if symID_got != symID {
+						gTest <- errors.New("SetSymbolID failed setup check")
+					}
+				}
+				running.Done()
+			}()
+		}
+
+		running.Wait()
+
+		if int(hardwireCount) != numWorkers*hardwireTestCount {
+			gTest <- errors.New("hardwire test count failed")
+		}
+
+	}
+
+	// Verify all the tokens are valid
+	for i, k := range vals {
+		IDs[i] = table.GetSymbolID(k, false)
+		if IDs[i] == 0 {
+			gTest <- errors.New("GetSymbolID failed final verification")
+		}
+		stored := table.LookupID(IDs[i])
+		if !bytes.Equal(stored, vals[i]) {
+			gTest <- errors.New("LookupID failed final verification")
+		}
+	}
+}
+
+func checkTable(db *badger.DB, vals [][]byte, IDs []symbol.ID) {
+	totalEntries := len(vals)
+
+	table, err := symbol.OpenTable(db, symbol.DefaultTableOpts)
+	if err != nil {
+		gTest <- err
+	}
+	defer table.Close()
+
+	// Check that all the tokens are present
+	{
+		running := &sync.WaitGroup{}
+		numWorkers := 5
+		for i := 0; i < numWorkers; i++ {
+			running.Add(1)
+			startAt := len(vals) * i / numWorkers
+			go func() {
+				for j := 0; j < totalEntries; j++ {
+					idx := (startAt + j) % totalEntries
+
+					if (j % numWorkers) == 0 {
+						symID := table.GetSymbolID(vals[idx], false)
+						if symID != IDs[idx] {
+							gTest <- errors.New("GetSymbolID failed readback check")
+						}
+					} else {
+						stored := table.LookupID(IDs[idx])
+						if !bytes.Equal(stored, vals[idx]) {
+							gTest <- errors.New("LookupID failed readback check")
+						}
+					}
+				}
+				running.Done()
+			}()
+		}
+
+		running.Wait()
+	}
+}


### PR DESCRIPTION
Donating `symbol.Table` if interested -- its testing is also good to go.  I'm open on any renaming, just lmk.  I think I said 6 bytes per ID but I meant 5 -- see comments for `type ID` for justification.   As I've been using this in the planet system, fully qualified (binary) internal keypaths look like:

`NodeID + AttrID + [SeriesIndex +] FromID`
5+5+[8+]5 => 23 (or 15) bytes -- not too shabby plus also allows for symbol aliasing (where multiple name identifiers are mapped to the same ID) -- e.g. a planet ID have it's base32 genesis hash, it's binary genesis hash, and ICANN domain name all map to the same ID.  